### PR TITLE
Spellbook menu clean

### DIFF
--- a/Code/Levels/main.gd
+++ b/Code/Levels/main.gd
@@ -3,7 +3,7 @@ extends Node2D
 
 @onready var game_level = preload("res://Scenes/Levels/Test/Main-Scene-Tom.tscn") as PackedScene
 @onready var level_select = preload("res://Scenes/UI/level_select.tscn") as PackedScene
-@onready var main_menu = preload("res://Scenes/UI/canvas_menu.tscn") as PackedScene
+@onready var main_menu = preload("res://Scenes/UI/canvas_menu.tscn").instantiate()
 @export var sound_manager : SoundManager
 @export var background : Background
 
@@ -35,10 +35,12 @@ func open_menu():
 	if current_game:
 		current_game.queue_free()  # Remove the current level
 	await get_tree().create_timer(0.1).timeout
-	var menu = main_menu.instantiate()
+	var menu = main_menu
 	var game_root = $"."
 	game_root.add_child(menu)
 	shopkeep_visible(false)
+	get_tree().reload_current_scene()
+	# WIP: for whatever reason, the menu that loads doesn't really work, its just the ui elements with no functionality. Must figure out way to make it actually the main menu.
 
 func play_sound(name : String):
 	sound_manager.play_sfx(name)

--- a/Code/Managers/LevelManager.gd
+++ b/Code/Managers/LevelManager.gd
@@ -18,6 +18,7 @@ func _ready() -> void:
 	check_frog_total()
 	$WinScreen.visible = false
 	$GameOver.visible = false
+	$SpellUi/Control.visible = false
 
 func array_to_dictionary(a : Array[MagicManager.FrogType]) -> Dictionary:
 	var dict = {}

--- a/Code/Managers/magic_manager.gd
+++ b/Code/Managers/magic_manager.gd
@@ -106,6 +106,23 @@ func get_spell_output(index: int) -> String:
 		_:
 			return "Unknown Spell"
 
+func output_to_index(frog:String):
+	# convert output from above func back to index
+	match frog:
+		"Basic Frog":
+			return 0
+		"Tropical Frog":
+			return 1
+		"Small Frog":
+			return 2
+		"Large Frog":
+			return 3
+		"Mud Frog":
+			return 4
+		_:
+			print("Frog Name Unknown")
+	
+
 func get_recipe_as_string(index: int) -> String:
 	if index < 0 or index >= spell_table.size():
 		return "Invalid spell index"
@@ -117,3 +134,14 @@ func get_recipe_as_string(index: int) -> String:
 		var frog_name = frog_type_names.get(frog_type, "Unknown Frog")
 		recipe_text += frog_name + ": " + str(recipe[frog_type]) + " "
 	return recipe_text
+
+func get_recipe_raw(index: int):
+	if index < 0 or index >= spell_table.size():
+		return "Invalid spell index"
+	
+	var recipe = spell_table[index]
+	return recipe
+	
+
+func get_spellbook_size():
+	return spell_table.size()

--- a/Code/Managers/sound_manager.gd
+++ b/Code/Managers/sound_manager.gd
@@ -24,6 +24,7 @@ extends Node2D
 	# round-robin style player
 # 6) BUS MANAGEMENT: (~418)
 	# logic used for volume sliders in settings menu 
+# 7) ADDITIONAL SETTINGS:
 
 # note: NOT ALL SOUNDS ARE FOUND ON SOUND MANAGER!!! frog charges and lillypad snaps are handled in their respective scripts
 
@@ -152,6 +153,10 @@ var roundrobin = 1 # used by SFX player, expected value 1-n where n is max sfx p
 @onready var audio_stream_player : AudioStreamPlayer = $PickupMXTheme
 @onready var audio_stream : AudioStreamSynchronized = audio_stream_player.stream
 
+# MENU, QUIT BUTTONS
+@onready var menu_button: Button = $menu_buttons/HBoxContainer/MainMenuButton as Button
+@onready var quit_button: Button = $menu_buttons/HBoxContainer/QuitButton as Button
+
 # music fade in/out
 #var cossfade_length = 0.5
 #var crossfade_delta = 0.05
@@ -206,7 +211,13 @@ var atmbus = AudioServer.get_bus_index("ATM")
 
 # setup ambiance
 func _ready() -> void:
+	# init buttons for pause menu
+	menu_button.button_down.connect(on_menu_pressed)
+	quit_button.button_down.connect(on_exit_pressed)
+	# play ambiance
 	set_ambiance_on(true)
+	
+	
 # toggle (not used yet)
 func set_ambiance_on(on : bool) -> void:
 	if on:
@@ -540,3 +551,15 @@ func _on_atm_slider_mouse_entered() -> void:
 	play_sfx("menu_hover")
 func _on_atm_toggle_mouse_entered() -> void:
 	play_sfx("menu_hover")
+
+# 7) ADDITIONAL SETTINGS
+
+func on_menu_pressed() -> void:
+	if get_tree().root.get_child(0) is Main:
+		get_tree().root.get_child(0).get_node("Canvas_Menu").check_frog_total()
+	if get_tree().root.get_child(0) is Main:
+		get_tree().root.get_child(0).open_menu()
+	
+	
+func on_exit_pressed() -> void:
+	get_tree().quit()

--- a/Code/Managers/sound_manager.gd
+++ b/Code/Managers/sound_manager.gd
@@ -555,8 +555,8 @@ func _on_atm_toggle_mouse_entered() -> void:
 # 7) ADDITIONAL SETTINGS
 
 func on_menu_pressed() -> void:
-	if get_tree().root.get_child(0) is Main:
-		get_tree().root.get_child(0).get_node("Canvas_Menu").check_frog_total()
+	#get_tree().current_scene.get_node("%Canvas_Shop").menu_closed.emit
+	# figure out how to make menu closed
 	if get_tree().root.get_child(0) is Main:
 		get_tree().root.get_child(0).open_menu()
 	

--- a/Code/Managers/sound_manager.gd
+++ b/Code/Managers/sound_manager.gd
@@ -559,6 +559,7 @@ func on_menu_pressed() -> void:
 	# figure out how to make menu closed
 	if get_tree().root.get_child(0) is Main:
 		get_tree().root.get_child(0).open_menu()
+	get_tree().paused = false
 	
 	
 func on_exit_pressed() -> void:

--- a/Code/UI/canvas_shop.gd
+++ b/Code/UI/canvas_shop.gd
@@ -4,6 +4,7 @@ class_name CanvasShop
 
 var animation : AnimationPlayer
 
+
 # Called when the node enters the scene tree for the first time.
 func _ready() -> void:
 	# Connect the signal 'animation_finished' to the function '_on_animation_finished'
@@ -18,6 +19,7 @@ func _on_back_button_pressed() -> void:
 		if get_tree().root.get_child(0).get_node("LevelManager") is LevelManager:
 			get_tree().root.get_child(0).get_node("LevelManager").check_frog_total()
 		else : get_tree().root.get_child(0).sound_manager.change_music_layer(0)
+
 
 func _on_open_button_pressed() -> void:
 	if get_tree().root.get_child(0) is Main:

--- a/Code/UI/canvas_shop.gd
+++ b/Code/UI/canvas_shop.gd
@@ -3,16 +3,22 @@ extends CanvasLayer
 class_name CanvasShop
 
 var animation : AnimationPlayer
+signal menu_closed()
+signal menu_opened()
 
+var opened = false
 
 # Called when the node enters the scene tree for the first time.
 func _ready() -> void:
 	# Connect the signal 'animation_finished' to the function '_on_animation_finished'
 	animation = get_node("Animation_Panel")
 	animation.connect("animation_finished", Callable(self, "_on_animation_finished"))
+	# set up buttons
 	
+	get_node("Menu/Back_Button").pressed.connect(_on_menu_closed)
+	get_node("Open_Button").pressed.connect(_on_menu_opened)
 
-func _on_back_button_pressed() -> void:
+func _on_menu_closed():
 	animation.play("Transition_Out")
 	$Open_Button.visible = true
 	if get_tree().root.get_child(0) is Main:
@@ -20,8 +26,7 @@ func _on_back_button_pressed() -> void:
 			get_tree().root.get_child(0).get_node("LevelManager").check_frog_total()
 		else : get_tree().root.get_child(0).sound_manager.change_music_layer(0)
 
-
-func _on_open_button_pressed() -> void:
+func _on_menu_opened():
 	if get_tree().root.get_child(0) is Main:
 		get_tree().root.get_child(0).play_shop_music(true)
 	animation.play("Transition_In")

--- a/Code/UI/main_menu.gd
+++ b/Code/UI/main_menu.gd
@@ -3,21 +3,31 @@ extends Control
 
 
 @onready var start_button: Button = $MarginContainer/HBoxContainer/VBoxContainer/StartButton as Button
+@onready var lvl_select_button: Button = $MarginContainer/HBoxContainer/VBoxContainer/LvlSelectButton as Button
 #@onready var settings_button: Button = $MarginContainer/HBoxContainer/VBoxContainer/SettingsButton as Button
 @onready var credits_button: Button = $MarginContainer/HBoxContainer/VBoxContainer/CreditsButton as Button
 @onready var exit_button: Button = $MarginContainer/HBoxContainer/VBoxContainer/QuitButton as Button
 #@onready var settings_menu = preload("res://Scenes/UI/SettingsMenu.tscn") as PackedScene
 @onready var credits_menu = preload("res://Scenes/UI/CreditsMenu.tscn") as PackedScene
 
+
 @export var main : Main
 
 func _ready():
 	start_button.button_down.connect(on_start_pressed)
+	lvl_select_button.button_down.connect(on_lvl_select_pressed)
 	credits_button.button_down.connect(on_credits_pressed)
 	exit_button.button_down.connect(on_exit_pressed)
 
 
 func on_start_pressed() -> void:
+	if get_tree().root.get_child(0) is Main:
+		get_tree().root.get_child(0).open_gameplay(0)
+		queue_free()
+	else:
+		print("go to Main scene")
+
+func on_lvl_select_pressed() -> void:
 	if get_tree().root.get_child(0) is Main:
 		get_tree().root.get_child(0).open_level_select()
 		queue_free()

--- a/Code/UI/spell_ui.gd
+++ b/Code/UI/spell_ui.gd
@@ -13,11 +13,17 @@ var animation : AnimationPlayer
 @export var text7 : Label
 @export var text8 : Label
 
+# all spells, as outlined in magic manager, at init. currently does not update mid-game
 var spellbook = {}
+# index for which spell is currently displayed if there are more than one recipe
+var spelldisplayindex = {}
+
+var spellbook_open = false
 
 #lengths of menu items to calculate how many periods to use
 var dot_unit = 11
 var frog_unit = 150
+var update_time = 2
 
 func _ready() -> void:
 	# Connect the signal 'animation_finished' to the function '_on_animation_finished'
@@ -34,9 +40,11 @@ func get_spells() -> void:
 		var product = magic.output_to_index(magic.get_spell_output(index))
 		var spell = magic.get_recipe_raw(index)
 		if product in spellbook:
+			# add additional spell option
 			spellbook[product].append(spell)
 		else:
 			spellbook[product] = [spell]
+			spelldisplayindex[product] = 0
 		# print(spellbook) --> { 0: [{ 1: 1 }, { 2: 1 }, { 3: 1 }, { 4: 1 }, { 0: 1 }], 1: [{ 0: 3 }], 4: [{ 1: 3 }], 2: [{ 0: 2, 1: 2 }], 3: [{ 2: 3, 4: 3 }] }
 		# format: frog index: [first recipe:{needed frog type : qty}, second recipe:{1st needed frog type: qty, 2nd needed frog type : qty}]
 	for spell_line in range(0,spellbook.size()):
@@ -47,6 +55,7 @@ func update_spell_line(spell, spellnum): # index of spell in spellbook, index of
 	# get node path
 	var spell_path = ""
 	var dot_length = 630
+	var prefix = ""
 	match spell:
 		0:
 			spell_path = "Control/MarginContainer/HBoxContainer/NormRecipe"
@@ -58,13 +67,23 @@ func update_spell_line(spell, spellnum): # index of spell in spellbook, index of
 			spell_path = "Control/MarginContainer/HBoxContainer/FatRecipe"
 		4:
 			spell_path = "Control/MarginContainer/HBoxContainer/MudRecipe"
+	
+	# quantity prefix assign
+	if spell == 0:
+		# note: bandaid fix for basic frog, will not work for other "any" recipes if we added in future
+		prefix = "\n(any) x"
+		dot_length -= 55
+	else:
+		#standard prefix
+		prefix = "\nx"
+	
 	# iterate thru all the products in spellbook
 	var current_recipe = (spellbook[spell][spellnum])
 	# basic
 	if 0 in current_recipe:
 		get_node(spell_path + "/BasicImg").visible = true
 		get_node(spell_path + "/BasicQty").visible = true
-		get_node(spell_path + "/BasicQty").text = "\nx"+str(spellbook[spell][spellnum][0])
+		get_node(spell_path + "/BasicQty").text = prefix+str(spellbook[spell][spellnum][0])
 		get_node(spell_path + "/VSeparatorBasic").visible = true
 		get_node(spell_path + "/VSeparatorBasic2").visible = true
 		dot_length -= frog_unit
@@ -77,7 +96,7 @@ func update_spell_line(spell, spellnum): # index of spell in spellbook, index of
 	if 1 in current_recipe:
 		get_node(spell_path + "/TropImg").visible = true
 		get_node(spell_path + "/TropQty").visible = true
-		get_node(spell_path + "/TropQty").text = "\nx"+str(spellbook[spell][spellnum][1])
+		get_node(spell_path + "/TropQty").text = prefix+str(spellbook[spell][spellnum][1])
 		get_node(spell_path + "/VSeparatorTrop").visible = true
 		get_node(spell_path + "/VSeparatorTrop2").visible = true
 		dot_length -= frog_unit
@@ -90,7 +109,7 @@ func update_spell_line(spell, spellnum): # index of spell in spellbook, index of
 	if 2 in current_recipe:
 		get_node(spell_path + "/SmallImg").visible = true
 		get_node(spell_path + "/SmallQty").visible = true
-		get_node(spell_path + "/SmallQty").text = "\nx"+str(spellbook[spell][spellnum][2])
+		get_node(spell_path + "/SmallQty").text = prefix+str(spellbook[spell][spellnum][2])
 		get_node(spell_path + "/VSeparatorSmall").visible = true
 		get_node(spell_path + "/VSeparatorSmall2").visible = true
 		dot_length -= frog_unit
@@ -103,7 +122,7 @@ func update_spell_line(spell, spellnum): # index of spell in spellbook, index of
 	if 3 in current_recipe:
 		get_node(spell_path + "/LargeImg").visible = true
 		get_node(spell_path + "/LargeQty").visible = true
-		get_node(spell_path + "/LargeQty").text = "\nx"+str(spellbook[spell][spellnum][3])
+		get_node(spell_path + "/LargeQty").text = prefix+str(spellbook[spell][spellnum][3])
 		get_node(spell_path + "/VSeparatorLarge").visible = true
 		get_node(spell_path + "/VSeparatorLarge2").visible = true
 		dot_length -= frog_unit
@@ -116,7 +135,7 @@ func update_spell_line(spell, spellnum): # index of spell in spellbook, index of
 	if 4 in current_recipe:
 		get_node(spell_path + "/MudImg").visible = true
 		get_node(spell_path + "/MudQty").visible = true
-		get_node(spell_path + "/MudQty").text = "\nx"+str(spellbook[spell][spellnum][4])
+		get_node(spell_path + "/MudQty").text = prefix+str(spellbook[spell][spellnum][4])
 		get_node(spell_path + "/VSeparatorMud").visible = true
 		get_node(spell_path + "/VSeparatorMud2").visible = true
 		dot_length -= frog_unit
@@ -124,13 +143,18 @@ func update_spell_line(spell, spellnum): # index of spell in spellbook, index of
 		get_node(spell_path + "/MudImg").visible = false
 		get_node(spell_path + "/MudQty").visible = false
 		get_node(spell_path + "/VSeparatorMud").visible = false
-		get_node(spell_path + "/VSeparatorMud2").visible = false
+		get_node(spell_path + "/VSeparatorMud2").visible = false	
+	
 	# assign dots
 	var dot_text = "\n"
 	while dot_length >= 0:
 		dot_text += ". "
 		dot_length -= dot_unit
 	get_node(spell_path + "/DotSpacers").text = dot_text
+	# move spell index
+	spelldisplayindex[spell] += 1
+	if spelldisplayindex[spell] >= spellbook[spell].size():
+		spelldisplayindex[spell] = 0
 		
 
 func _on_open_button_pressed() -> void:
@@ -141,6 +165,15 @@ func _on_open_button_pressed() -> void:
 	$OpenButton.visible = false
 	$Control.visible = true
 	#get_tree().paused = true
+	spellbook_open = true
+	# loop through spells until close
+	while spellbook_open == true:
+		await get_tree().create_timer(update_time).timeout
+		for spell_line in range(0,spellbook.size()):
+			# only update spells w multiple recipes
+			if spellbook[spell_line].size() > 1:
+				update_spell_line(spell_line, spelldisplayindex[spell_line])
+	
 
 
 func _on_animation_finished(anim_name: String) -> void:
@@ -154,3 +187,5 @@ func _on_animation_finished(anim_name: String) -> void:
 func _on_close_button_pressed() -> void:
 	animation.play("Transition_Out")
 	$OpenButton.visible = true
+	# end spellbook recipe loop
+	spellbook_open = false

--- a/Code/UI/spell_ui.gd
+++ b/Code/UI/spell_ui.gd
@@ -37,6 +37,7 @@ func _on_open_button_pressed() -> void:
 		#get_tree().root.get_child(0).play_shop_music(true)
 	animation.play("Transition_In")
 	$OpenButton.visible = false
+	$Control.visible = true
 	#get_tree().paused = true
 
 

--- a/Code/UI/spell_ui.gd
+++ b/Code/UI/spell_ui.gd
@@ -13,26 +13,128 @@ var animation : AnimationPlayer
 @export var text7 : Label
 @export var text8 : Label
 
+var spellbook = {}
+
+#lengths of menu items to calculate how many periods to use
+var dot_unit = 11
+var frog_unit = 150
+
 func _ready() -> void:
 	# Connect the signal 'animation_finished' to the function '_on_animation_finished'
 	animation = get_node("AnimationPlayer")
 	animation.connect("animation_finished", Callable(self, "_on_animation_finished"))
 	animation.play("Start")
+	get_spells()
 
-func update_text() -> void:
-	text0.text = magic.get_recipe_as_string(0)
-	text1.text = magic.get_recipe_as_string(1)
-	text2.text = magic.get_recipe_as_string(2)
-	text3.text = magic.get_recipe_as_string(3)
-	text4.text = magic.get_recipe_as_string(4)
-	text5.text = magic.get_recipe_as_string(5)
-	text6.text = magic.get_recipe_as_string(6)
-	text7.text = magic.get_recipe_as_string(7)
-	text8.text = magic.get_recipe_as_string(8)
+# magic manager index: 0 BASIC, 1 TROPICAL, 2 SMALL, 3 FAT, 4 MUD }
 
+func get_spells() -> void:
+	#process every entry in spellbook
+	for index in range(0,magic.get_spellbook_size()):
+		var product = magic.output_to_index(magic.get_spell_output(index))
+		var spell = magic.get_recipe_raw(index)
+		if product in spellbook:
+			spellbook[product].append(spell)
+		else:
+			spellbook[product] = [spell]
+		# print(spellbook) --> { 0: [{ 1: 1 }, { 2: 1 }, { 3: 1 }, { 4: 1 }, { 0: 1 }], 1: [{ 0: 3 }], 4: [{ 1: 3 }], 2: [{ 0: 2, 1: 2 }], 3: [{ 2: 3, 4: 3 }] }
+		# format: frog index: [first recipe:{needed frog type : qty}, second recipe:{1st needed frog type: qty, 2nd needed frog type : qty}]
+	for spell_line in range(0,spellbook.size()):
+		update_spell_line(spell_line, 0)
+		
+# magic manager index: 0 BASIC, 1 TROPICAL, 2 SMALL, 3 FAT, 4 MUD }
+func update_spell_line(spell, spellnum): # index of spell in spellbook, index of recipe for product
+	# get node path
+	var spell_path = ""
+	var dot_length = 630
+	match spell:
+		0:
+			spell_path = "Control/MarginContainer/HBoxContainer/NormRecipe"
+		1:
+			spell_path = "Control/MarginContainer/HBoxContainer/TropRecipe"
+		2:
+			spell_path = "Control/MarginContainer/HBoxContainer/SmallRecipe"
+		3:
+			spell_path = "Control/MarginContainer/HBoxContainer/FatRecipe"
+		4:
+			spell_path = "Control/MarginContainer/HBoxContainer/MudRecipe"
+	# iterate thru all the products in spellbook
+	var current_recipe = (spellbook[spell][spellnum])
+	# basic
+	if 0 in current_recipe:
+		get_node(spell_path + "/BasicImg").visible = true
+		get_node(spell_path + "/BasicQty").visible = true
+		get_node(spell_path + "/BasicQty").text = "\nx"+str(spellbook[spell][spellnum][0])
+		get_node(spell_path + "/VSeparatorBasic").visible = true
+		get_node(spell_path + "/VSeparatorBasic2").visible = true
+		dot_length -= frog_unit
+	else:
+		get_node(spell_path + "/BasicImg").visible = false
+		get_node(spell_path + "/BasicQty").visible = false
+		get_node(spell_path + "/VSeparatorBasic").visible = false
+		get_node(spell_path + "/VSeparatorBasic2").visible = false
+	# trop
+	if 1 in current_recipe:
+		get_node(spell_path + "/TropImg").visible = true
+		get_node(spell_path + "/TropQty").visible = true
+		get_node(spell_path + "/TropQty").text = "\nx"+str(spellbook[spell][spellnum][1])
+		get_node(spell_path + "/VSeparatorTrop").visible = true
+		get_node(spell_path + "/VSeparatorTrop2").visible = true
+		dot_length -= frog_unit
+	else:
+		get_node(spell_path + "/TropImg").visible = false
+		get_node(spell_path + "/TropQty").visible = false
+		get_node(spell_path + "/VSeparatorTrop").visible = false
+		get_node(spell_path + "/VSeparatorTrop2").visible = false
+	# small
+	if 2 in current_recipe:
+		get_node(spell_path + "/SmallImg").visible = true
+		get_node(spell_path + "/SmallQty").visible = true
+		get_node(spell_path + "/SmallQty").text = "\nx"+str(spellbook[spell][spellnum][2])
+		get_node(spell_path + "/VSeparatorSmall").visible = true
+		get_node(spell_path + "/VSeparatorSmall2").visible = true
+		dot_length -= frog_unit
+	else:
+		get_node(spell_path + "/SmallImg").visible = false
+		get_node(spell_path + "/SmallQty").visible = false
+		get_node(spell_path + "/VSeparatorSmall").visible = false
+		get_node(spell_path + "/VSeparatorSmall2").visible = false
+	# fat
+	if 3 in current_recipe:
+		get_node(spell_path + "/LargeImg").visible = true
+		get_node(spell_path + "/LargeQty").visible = true
+		get_node(spell_path + "/LargeQty").text = "\nx"+str(spellbook[spell][spellnum][3])
+		get_node(spell_path + "/VSeparatorLarge").visible = true
+		get_node(spell_path + "/VSeparatorLarge2").visible = true
+		dot_length -= frog_unit
+	else:
+		get_node(spell_path + "/LargeImg").visible = false
+		get_node(spell_path + "/LargeQty").visible = false
+		get_node(spell_path + "/VSeparatorLarge").visible = false
+		get_node(spell_path + "/VSeparatorLarge2").visible = false
+	# mud
+	if 4 in current_recipe:
+		get_node(spell_path + "/MudImg").visible = true
+		get_node(spell_path + "/MudQty").visible = true
+		get_node(spell_path + "/MudQty").text = "\nx"+str(spellbook[spell][spellnum][4])
+		get_node(spell_path + "/VSeparatorMud").visible = true
+		get_node(spell_path + "/VSeparatorMud2").visible = true
+		dot_length -= frog_unit
+	else:
+		get_node(spell_path + "/MudImg").visible = false
+		get_node(spell_path + "/MudQty").visible = false
+		get_node(spell_path + "/VSeparatorMud").visible = false
+		get_node(spell_path + "/VSeparatorMud2").visible = false
+	# assign dots
+	var dot_text = "\n"
+	while dot_length >= 0:
+		dot_text += ". "
+		dot_length -= dot_unit
+	get_node(spell_path + "/DotSpacers").text = dot_text
+		
 
 func _on_open_button_pressed() -> void:
-	update_text()
+	#update_spells()
 	#if get_tree().root.get_child(0) is Main:
 		#get_tree().root.get_child(0).play_shop_music(true)
 	animation.play("Transition_In")

--- a/Scenes/FrogDetectionArea.tscn
+++ b/Scenes/FrogDetectionArea.tscn
@@ -1,6 +1,5 @@
-[gd_scene load_steps=5 format=3 uid="uid://d3r6wmwxqowp4"]
+[gd_scene load_steps=4 format=3 uid="uid://d3r6wmwxqowp4"]
 
-[ext_resource type="Texture2D" uid="uid://cmsts1ssqh3cs" path="res://Assets/Art/Temp/placeholder.png" id="1_alkt3"]
 [ext_resource type="Script" path="res://Code/Legacy/frog_detection_area.gd" id="1_ppca7"]
 [ext_resource type="Texture2D" uid="uid://cc1xaaeiuebob" path="res://Assets/Art/Background/swamp_bg.png" id="3_5jox3"]
 
@@ -9,11 +8,6 @@ size = Vector2(1920, 289)
 
 [node name="FrogDetectionArea" type="Area2D"]
 script = ExtResource("1_ppca7")
-
-[node name="Sprite2D" type="Sprite2D" parent="."]
-position = Vector2(-4.76837e-07, -4.76837e-07)
-scale = Vector2(2, 2)
-texture = ExtResource("1_alkt3")
 
 [node name="SwampBg" type="Sprite2D" parent="."]
 visible = false

--- a/Scenes/Managers/sound_manager.tscn
+++ b/Scenes/Managers/sound_manager.tscn
@@ -1,7 +1,8 @@
-[gd_scene load_steps=15 format=3 uid="uid://1k1rcvp03xma"]
+[gd_scene load_steps=16 format=3 uid="uid://1k1rcvp03xma"]
 
 [ext_resource type="Script" path="res://Code/Managers/sound_manager.gd" id="1_spyt0"]
 [ext_resource type="PackedScene" uid="uid://bw0yhqbfc0xq" path="res://Scenes/UI/AudioManagerControls.tscn" id="2_jp7r5"]
+[ext_resource type="PackedScene" uid="uid://baeaj55y6xd38" path="res://Scenes/UI/BlankButton.tscn" id="3_5ghk0"]
 [ext_resource type="AudioStream" uid="uid://u3cq4x2o7dvj" path="res://Assets/Audio/Music/GWJ73_MX_main_layer00_zeroOrMoreFrogs_73bpm.wav" id="3_26e3e"]
 [ext_resource type="AudioStream" uid="uid://cnsvybkk4xp8w" path="res://Assets/Audio/Music/GWJ73_MX_main_layer01_oneOrMoreFrogs_73bpm.wav" id="4_6y7wp"]
 [ext_resource type="AudioStream" uid="uid://kijxj3q23ga3" path="res://Assets/Audio/Music/GWJ73_MX_main_layer02_threeOrMoreFrogs_73bpm.wav" id="5_j571n"]
@@ -105,6 +106,60 @@ button_pressed = true
 
 [node name="ATMToggle" parent="AudioManagerControls/HBoxContainer/VBoxContainer2" index="3"]
 button_pressed = true
+
+[node name="VBoxContainer4" type="VBoxContainer" parent="AudioManagerControls/HBoxContainer" index="3"]
+visible = false
+layout_mode = 2
+
+[node name="menu_buttons" type="VBoxContainer" parent="."]
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -150.0
+offset_top = 85.0
+offset_right = 150.0
+offset_bottom = 145.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="HBoxContainer" type="HBoxContainer" parent="menu_buttons"]
+layout_mode = 2
+
+[node name="MainMenuButton" parent="menu_buttons/HBoxContainer" instance=ExtResource("3_5ghk0")]
+layout_mode = 2
+theme_override_font_sizes/font_size = 34
+text = "  Main Menu  "
+
+[node name="VSeparator" type="VSeparator" parent="menu_buttons/HBoxContainer"]
+visibility_layer = 0
+layout_mode = 2
+
+[node name="VSeparator2" type="VSeparator" parent="menu_buttons/HBoxContainer"]
+visibility_layer = 0
+layout_mode = 2
+
+[node name="VSeparator3" type="VSeparator" parent="menu_buttons/HBoxContainer"]
+visibility_layer = 0
+layout_mode = 2
+
+[node name="VSeparator4" type="VSeparator" parent="menu_buttons/HBoxContainer"]
+visibility_layer = 0
+layout_mode = 2
+
+[node name="VSeparator6" type="VSeparator" parent="menu_buttons/HBoxContainer"]
+visibility_layer = 0
+layout_mode = 2
+
+[node name="VSeparator5" type="VSeparator" parent="menu_buttons/HBoxContainer"]
+visibility_layer = 0
+layout_mode = 2
+
+[node name="QuitButton" parent="menu_buttons/HBoxContainer" instance=ExtResource("3_5ghk0")]
+layout_mode = 2
+theme_override_font_sizes/font_size = 34
+text = "  Quit  "
 
 [node name="PickupMXTheme" type="AudioStreamPlayer" parent="."]
 stream = SubResource("AudioStreamSynchronized_5fiec")

--- a/Scenes/UI/Levels/Main.tscn
+++ b/Scenes/UI/Levels/Main.tscn
@@ -5,9 +5,8 @@
 [ext_resource type="PackedScene" uid="uid://cwk0xas0ckfjo" path="res://Scenes/UI/MainMenu.tscn" id="2_aetre"]
 [ext_resource type="PackedScene" uid="uid://d25bf5qdgn1h5" path="res://Scenes/Environment/Background.tscn" id="2_xhy1p"]
 
-[node name="Main" type="Node2D" node_paths=PackedStringArray("sound_manager", "background")]
+[node name="Main" type="Node2D" node_paths=PackedStringArray("background")]
 script = ExtResource("1_aqv4j")
-sound_manager = NodePath("Canvas_Pause/Menu/SettingsMenu/Panel/MarginContainer2/HBoxContainer/SoundManager")
 background = NodePath("Background")
 
 [node name="Background" parent="." instance=ExtResource("2_xhy1p")]

--- a/Scenes/UI/MainMenu.tscn
+++ b/Scenes/UI/MainMenu.tscn
@@ -62,6 +62,10 @@ layout_mode = 2
 layout_mode = 2
 text = "Start"
 
+[node name="LvlSelectButton" parent="MarginContainer/HBoxContainer/VBoxContainer" instance=ExtResource("3_stxqm")]
+layout_mode = 2
+text = " Level Select "
+
 [node name="CreditsButton" parent="MarginContainer/HBoxContainer/VBoxContainer" instance=ExtResource("3_stxqm")]
 layout_mode = 2
 text = "Credits"

--- a/Scenes/UI/SettingsMenu.tscn
+++ b/Scenes/UI/SettingsMenu.tscn
@@ -45,6 +45,7 @@ vertical_alignment = 1
 
 [node name="Button1" type="Sprite2D" parent="."]
 position = Vector2(982, 532)
+scale = Vector2(1, 1.2)
 texture = ExtResource("3_pyryx")
 
 [node name="MarginContainer2" type="MarginContainer" parent="Button1"]
@@ -57,6 +58,7 @@ offset_right = -746.0
 offset_bottom = -272.0
 grow_horizontal = 2
 grow_vertical = 2
+scale = Vector2(1, 0.9)
 theme_override_constants/margin_left = 20
 theme_override_constants/margin_top = 20
 theme_override_constants/margin_right = 20

--- a/Scenes/UI/spe123C.tmp
+++ b/Scenes/UI/spe123C.tmp
@@ -348,10 +348,6 @@ x1
 modulate = Color(1, 1, 1, 0)
 layout_mode = 2
 
-[node name="VSeparatorLarge2" type="VSeparator" parent="Control/MarginContainer/HBoxContainer/NormRecipe"]
-modulate = Color(1, 1, 1, 0)
-layout_mode = 2
-
 [node name="DotSpacers" type="Label" parent="Control/MarginContainer/HBoxContainer/NormRecipe"]
 layout_mode = 2
 theme_override_colors/font_color = Color(0, 0, 0, 1)
@@ -491,10 +487,6 @@ x1
 "
 
 [node name="VSeparatorLarge" type="VSeparator" parent="Control/MarginContainer/HBoxContainer/TropRecipe"]
-modulate = Color(1, 1, 1, 0)
-layout_mode = 2
-
-[node name="VSeparatorLarge2" type="VSeparator" parent="Control/MarginContainer/HBoxContainer/TropRecipe"]
 modulate = Color(1, 1, 1, 0)
 layout_mode = 2
 
@@ -640,10 +632,6 @@ x1
 modulate = Color(1, 1, 1, 0)
 layout_mode = 2
 
-[node name="VSeparatorLarge2" type="VSeparator" parent="Control/MarginContainer/HBoxContainer/MudRecipe"]
-modulate = Color(1, 1, 1, 0)
-layout_mode = 2
-
 [node name="DotSpacers" type="Label" parent="Control/MarginContainer/HBoxContainer/MudRecipe"]
 layout_mode = 2
 theme_override_colors/font_color = Color(0, 0, 0, 1)
@@ -786,10 +774,6 @@ x1
 modulate = Color(1, 1, 1, 0)
 layout_mode = 2
 
-[node name="VSeparatorLarge2" type="VSeparator" parent="Control/MarginContainer/HBoxContainer/SmallRecipe"]
-modulate = Color(1, 1, 1, 0)
-layout_mode = 2
-
 [node name="DotSpacers" type="Label" parent="Control/MarginContainer/HBoxContainer/SmallRecipe"]
 layout_mode = 2
 theme_override_colors/font_color = Color(0, 0, 0, 1)
@@ -810,21 +794,21 @@ layout_mode = 2
 texture = ExtResource("7_fip3l")
 expand_mode = 5
 
-[node name="FatRecipe" type="HBoxContainer" parent="Control/MarginContainer/HBoxContainer"]
+[node name="LargeRecipe" type="HBoxContainer" parent="Control/MarginContainer/HBoxContainer"]
 custom_minimum_size = Vector2(0, 10)
 layout_mode = 2
 size_flags_horizontal = 4
 size_flags_vertical = 4
 alignment = 1
 
-[node name="BasicImg" type="TextureRect" parent="Control/MarginContainer/HBoxContainer/FatRecipe"]
+[node name="BasicImg" type="TextureRect" parent="Control/MarginContainer/HBoxContainer/LargeRecipe"]
 clip_contents = true
 custom_minimum_size = Vector2(100, 0)
 layout_mode = 2
 texture = ExtResource("4_o8vp7")
 expand_mode = 5
 
-[node name="BasicQty" type="Label" parent="Control/MarginContainer/HBoxContainer/FatRecipe"]
+[node name="BasicQty" type="Label" parent="Control/MarginContainer/HBoxContainer/LargeRecipe"]
 layout_mode = 2
 theme_override_colors/font_color = Color(0, 0, 0, 1)
 theme_override_fonts/font = ExtResource("3_nq4v7")
@@ -832,21 +816,21 @@ theme_override_font_sizes/font_size = 22
 text = "
 x1"
 
-[node name="VSeparatorBasic" type="VSeparator" parent="Control/MarginContainer/HBoxContainer/FatRecipe"]
+[node name="VSeparatorBasic" type="VSeparator" parent="Control/MarginContainer/HBoxContainer/LargeRecipe"]
 modulate = Color(1, 1, 1, 0)
 layout_mode = 2
 
-[node name="VSeparatorBasic2" type="VSeparator" parent="Control/MarginContainer/HBoxContainer/FatRecipe"]
+[node name="VSeparatorBasic2" type="VSeparator" parent="Control/MarginContainer/HBoxContainer/LargeRecipe"]
 modulate = Color(1, 1, 1, 0)
 layout_mode = 2
 
-[node name="TropImg" type="TextureRect" parent="Control/MarginContainer/HBoxContainer/FatRecipe"]
+[node name="TropImg" type="TextureRect" parent="Control/MarginContainer/HBoxContainer/LargeRecipe"]
 custom_minimum_size = Vector2(100, 0)
 layout_mode = 2
 texture = ExtResource("5_7xe46")
 expand_mode = 3
 
-[node name="TropQty" type="Label" parent="Control/MarginContainer/HBoxContainer/FatRecipe"]
+[node name="TropQty" type="Label" parent="Control/MarginContainer/HBoxContainer/LargeRecipe"]
 layout_mode = 2
 theme_override_colors/font_color = Color(0, 0, 0, 1)
 theme_override_fonts/font = ExtResource("3_nq4v7")
@@ -854,22 +838,22 @@ theme_override_font_sizes/font_size = 22
 text = "
 x1"
 
-[node name="VSeparatorTrop" type="VSeparator" parent="Control/MarginContainer/HBoxContainer/FatRecipe"]
+[node name="VSeparatorTrop" type="VSeparator" parent="Control/MarginContainer/HBoxContainer/LargeRecipe"]
 modulate = Color(1, 1, 1, 0)
 layout_mode = 2
 
-[node name="VSeparatorTrop2" type="VSeparator" parent="Control/MarginContainer/HBoxContainer/FatRecipe"]
+[node name="VSeparatorTrop2" type="VSeparator" parent="Control/MarginContainer/HBoxContainer/LargeRecipe"]
 modulate = Color(1, 1, 1, 0)
 layout_mode = 2
 
-[node name="MudImg" type="TextureRect" parent="Control/MarginContainer/HBoxContainer/FatRecipe"]
+[node name="MudImg" type="TextureRect" parent="Control/MarginContainer/HBoxContainer/LargeRecipe"]
 custom_minimum_size = Vector2(100, 0)
 layout_mode = 2
 texture = ExtResource("6_7x30o")
 expand_mode = 3
 flip_h = true
 
-[node name="MudQty" type="Label" parent="Control/MarginContainer/HBoxContainer/FatRecipe"]
+[node name="MudQty" type="Label" parent="Control/MarginContainer/HBoxContainer/LargeRecipe"]
 layout_mode = 2
 theme_override_colors/font_color = Color(0, 0, 0, 1)
 theme_override_fonts/font = ExtResource("3_nq4v7")
@@ -878,21 +862,21 @@ text = "
 x1
 "
 
-[node name="VSeparatorMud" type="VSeparator" parent="Control/MarginContainer/HBoxContainer/FatRecipe"]
+[node name="VSeparatorMud" type="VSeparator" parent="Control/MarginContainer/HBoxContainer/LargeRecipe"]
 modulate = Color(1, 1, 1, 0)
 layout_mode = 2
 
-[node name="VSeparatorMud2" type="VSeparator" parent="Control/MarginContainer/HBoxContainer/FatRecipe"]
+[node name="VSeparatorMud2" type="VSeparator" parent="Control/MarginContainer/HBoxContainer/LargeRecipe"]
 modulate = Color(1, 1, 1, 0)
 layout_mode = 2
 
-[node name="SmallImg" type="TextureRect" parent="Control/MarginContainer/HBoxContainer/FatRecipe"]
+[node name="SmallImg" type="TextureRect" parent="Control/MarginContainer/HBoxContainer/LargeRecipe"]
 custom_minimum_size = Vector2(100, 0)
 layout_mode = 2
 texture = ExtResource("7_fip3l")
 expand_mode = 3
 
-[node name="SmallQty" type="Label" parent="Control/MarginContainer/HBoxContainer/FatRecipe"]
+[node name="SmallQty" type="Label" parent="Control/MarginContainer/HBoxContainer/LargeRecipe"]
 layout_mode = 2
 size_flags_horizontal = 4
 size_flags_vertical = 1
@@ -904,22 +888,22 @@ x1
 "
 vertical_alignment = 1
 
-[node name="VSeparatorSmall" type="VSeparator" parent="Control/MarginContainer/HBoxContainer/FatRecipe"]
+[node name="VSeparatorSmall" type="VSeparator" parent="Control/MarginContainer/HBoxContainer/LargeRecipe"]
 modulate = Color(1, 1, 1, 0)
 layout_mode = 2
 
-[node name="VSeparatorSmall2" type="VSeparator" parent="Control/MarginContainer/HBoxContainer/FatRecipe"]
+[node name="VSeparatorSmall2" type="VSeparator" parent="Control/MarginContainer/HBoxContainer/LargeRecipe"]
 modulate = Color(1, 1, 1, 0)
 layout_mode = 2
 
-[node name="LargeImg" type="TextureRect" parent="Control/MarginContainer/HBoxContainer/FatRecipe"]
+[node name="LargeImg" type="TextureRect" parent="Control/MarginContainer/HBoxContainer/LargeRecipe"]
 custom_minimum_size = Vector2(100, 0)
 layout_mode = 2
 texture = ExtResource("8_nqhld")
 expand_mode = 3
 flip_h = true
 
-[node name="LargeQty" type="Label" parent="Control/MarginContainer/HBoxContainer/FatRecipe"]
+[node name="LargeQty" type="Label" parent="Control/MarginContainer/HBoxContainer/LargeRecipe"]
 layout_mode = 2
 theme_override_colors/font_color = Color(0, 0, 0, 1)
 theme_override_fonts/font = ExtResource("3_nq4v7")
@@ -928,15 +912,11 @@ text = "
 x1
 "
 
-[node name="VSeparatorLarge" type="VSeparator" parent="Control/MarginContainer/HBoxContainer/FatRecipe"]
+[node name="VSeparatorLarge" type="VSeparator" parent="Control/MarginContainer/HBoxContainer/LargeRecipe"]
 modulate = Color(1, 1, 1, 0)
 layout_mode = 2
 
-[node name="VSeparatorLarge2" type="VSeparator" parent="Control/MarginContainer/HBoxContainer/FatRecipe"]
-modulate = Color(1, 1, 1, 0)
-layout_mode = 2
-
-[node name="DotSpacers" type="Label" parent="Control/MarginContainer/HBoxContainer/FatRecipe"]
+[node name="DotSpacers" type="Label" parent="Control/MarginContainer/HBoxContainer/LargeRecipe"]
 layout_mode = 2
 theme_override_colors/font_color = Color(0, 0, 0, 1)
 theme_override_fonts/font = ExtResource("3_nq4v7")
@@ -944,12 +924,12 @@ theme_override_font_sizes/font_size = 22
 text = "
 . . ."
 
-[node name="VSeparatorFinal" type="VSeparator" parent="Control/MarginContainer/HBoxContainer/FatRecipe"]
+[node name="VSeparatorFinal" type="VSeparator" parent="Control/MarginContainer/HBoxContainer/LargeRecipe"]
 visible = false
 modulate = Color(1, 1, 1, 0)
 layout_mode = 2
 
-[node name="LargeProduct" type="TextureRect" parent="Control/MarginContainer/HBoxContainer/FatRecipe"]
+[node name="LargeProduct" type="TextureRect" parent="Control/MarginContainer/HBoxContainer/LargeRecipe"]
 clip_contents = true
 custom_minimum_size = Vector2(100, 0)
 layout_mode = 2

--- a/Scenes/UI/speC0E2.tmp
+++ b/Scenes/UI/speC0E2.tmp
@@ -348,10 +348,6 @@ x1
 modulate = Color(1, 1, 1, 0)
 layout_mode = 2
 
-[node name="VSeparatorLarge2" type="VSeparator" parent="Control/MarginContainer/HBoxContainer/NormRecipe"]
-modulate = Color(1, 1, 1, 0)
-layout_mode = 2
-
 [node name="DotSpacers" type="Label" parent="Control/MarginContainer/HBoxContainer/NormRecipe"]
 layout_mode = 2
 theme_override_colors/font_color = Color(0, 0, 0, 1)
@@ -491,10 +487,6 @@ x1
 "
 
 [node name="VSeparatorLarge" type="VSeparator" parent="Control/MarginContainer/HBoxContainer/TropRecipe"]
-modulate = Color(1, 1, 1, 0)
-layout_mode = 2
-
-[node name="VSeparatorLarge2" type="VSeparator" parent="Control/MarginContainer/HBoxContainer/TropRecipe"]
 modulate = Color(1, 1, 1, 0)
 layout_mode = 2
 
@@ -640,10 +632,6 @@ x1
 modulate = Color(1, 1, 1, 0)
 layout_mode = 2
 
-[node name="VSeparatorLarge2" type="VSeparator" parent="Control/MarginContainer/HBoxContainer/MudRecipe"]
-modulate = Color(1, 1, 1, 0)
-layout_mode = 2
-
 [node name="DotSpacers" type="Label" parent="Control/MarginContainer/HBoxContainer/MudRecipe"]
 layout_mode = 2
 theme_override_colors/font_color = Color(0, 0, 0, 1)
@@ -786,10 +774,6 @@ x1
 modulate = Color(1, 1, 1, 0)
 layout_mode = 2
 
-[node name="VSeparatorLarge2" type="VSeparator" parent="Control/MarginContainer/HBoxContainer/SmallRecipe"]
-modulate = Color(1, 1, 1, 0)
-layout_mode = 2
-
 [node name="DotSpacers" type="Label" parent="Control/MarginContainer/HBoxContainer/SmallRecipe"]
 layout_mode = 2
 theme_override_colors/font_color = Color(0, 0, 0, 1)
@@ -810,21 +794,21 @@ layout_mode = 2
 texture = ExtResource("7_fip3l")
 expand_mode = 5
 
-[node name="FatRecipe" type="HBoxContainer" parent="Control/MarginContainer/HBoxContainer"]
+[node name="LargeRecipe" type="HBoxContainer" parent="Control/MarginContainer/HBoxContainer"]
 custom_minimum_size = Vector2(0, 10)
 layout_mode = 2
 size_flags_horizontal = 4
 size_flags_vertical = 4
 alignment = 1
 
-[node name="BasicImg" type="TextureRect" parent="Control/MarginContainer/HBoxContainer/FatRecipe"]
+[node name="BasicImg" type="TextureRect" parent="Control/MarginContainer/HBoxContainer/LargeRecipe"]
 clip_contents = true
 custom_minimum_size = Vector2(100, 0)
 layout_mode = 2
 texture = ExtResource("4_o8vp7")
 expand_mode = 5
 
-[node name="BasicQty" type="Label" parent="Control/MarginContainer/HBoxContainer/FatRecipe"]
+[node name="BasicQty" type="Label" parent="Control/MarginContainer/HBoxContainer/LargeRecipe"]
 layout_mode = 2
 theme_override_colors/font_color = Color(0, 0, 0, 1)
 theme_override_fonts/font = ExtResource("3_nq4v7")
@@ -832,21 +816,21 @@ theme_override_font_sizes/font_size = 22
 text = "
 x1"
 
-[node name="VSeparatorBasic" type="VSeparator" parent="Control/MarginContainer/HBoxContainer/FatRecipe"]
+[node name="VSeparatorBasic" type="VSeparator" parent="Control/MarginContainer/HBoxContainer/LargeRecipe"]
 modulate = Color(1, 1, 1, 0)
 layout_mode = 2
 
-[node name="VSeparatorBasic2" type="VSeparator" parent="Control/MarginContainer/HBoxContainer/FatRecipe"]
+[node name="VSeparatorBasic2" type="VSeparator" parent="Control/MarginContainer/HBoxContainer/LargeRecipe"]
 modulate = Color(1, 1, 1, 0)
 layout_mode = 2
 
-[node name="TropImg" type="TextureRect" parent="Control/MarginContainer/HBoxContainer/FatRecipe"]
+[node name="TropImg" type="TextureRect" parent="Control/MarginContainer/HBoxContainer/LargeRecipe"]
 custom_minimum_size = Vector2(100, 0)
 layout_mode = 2
 texture = ExtResource("5_7xe46")
 expand_mode = 3
 
-[node name="TropQty" type="Label" parent="Control/MarginContainer/HBoxContainer/FatRecipe"]
+[node name="TropQty" type="Label" parent="Control/MarginContainer/HBoxContainer/LargeRecipe"]
 layout_mode = 2
 theme_override_colors/font_color = Color(0, 0, 0, 1)
 theme_override_fonts/font = ExtResource("3_nq4v7")
@@ -854,22 +838,22 @@ theme_override_font_sizes/font_size = 22
 text = "
 x1"
 
-[node name="VSeparatorTrop" type="VSeparator" parent="Control/MarginContainer/HBoxContainer/FatRecipe"]
+[node name="VSeparatorTrop" type="VSeparator" parent="Control/MarginContainer/HBoxContainer/LargeRecipe"]
 modulate = Color(1, 1, 1, 0)
 layout_mode = 2
 
-[node name="VSeparatorTrop2" type="VSeparator" parent="Control/MarginContainer/HBoxContainer/FatRecipe"]
+[node name="VSeparatorTrop2" type="VSeparator" parent="Control/MarginContainer/HBoxContainer/LargeRecipe"]
 modulate = Color(1, 1, 1, 0)
 layout_mode = 2
 
-[node name="MudImg" type="TextureRect" parent="Control/MarginContainer/HBoxContainer/FatRecipe"]
+[node name="MudImg" type="TextureRect" parent="Control/MarginContainer/HBoxContainer/LargeRecipe"]
 custom_minimum_size = Vector2(100, 0)
 layout_mode = 2
 texture = ExtResource("6_7x30o")
 expand_mode = 3
 flip_h = true
 
-[node name="MudQty" type="Label" parent="Control/MarginContainer/HBoxContainer/FatRecipe"]
+[node name="MudQty" type="Label" parent="Control/MarginContainer/HBoxContainer/LargeRecipe"]
 layout_mode = 2
 theme_override_colors/font_color = Color(0, 0, 0, 1)
 theme_override_fonts/font = ExtResource("3_nq4v7")
@@ -878,21 +862,21 @@ text = "
 x1
 "
 
-[node name="VSeparatorMud" type="VSeparator" parent="Control/MarginContainer/HBoxContainer/FatRecipe"]
+[node name="VSeparatorMud" type="VSeparator" parent="Control/MarginContainer/HBoxContainer/LargeRecipe"]
 modulate = Color(1, 1, 1, 0)
 layout_mode = 2
 
-[node name="VSeparatorMud2" type="VSeparator" parent="Control/MarginContainer/HBoxContainer/FatRecipe"]
+[node name="VSeparatorMud2" type="VSeparator" parent="Control/MarginContainer/HBoxContainer/LargeRecipe"]
 modulate = Color(1, 1, 1, 0)
 layout_mode = 2
 
-[node name="SmallImg" type="TextureRect" parent="Control/MarginContainer/HBoxContainer/FatRecipe"]
+[node name="SmallImg" type="TextureRect" parent="Control/MarginContainer/HBoxContainer/LargeRecipe"]
 custom_minimum_size = Vector2(100, 0)
 layout_mode = 2
 texture = ExtResource("7_fip3l")
 expand_mode = 3
 
-[node name="SmallQty" type="Label" parent="Control/MarginContainer/HBoxContainer/FatRecipe"]
+[node name="SmallQty" type="Label" parent="Control/MarginContainer/HBoxContainer/LargeRecipe"]
 layout_mode = 2
 size_flags_horizontal = 4
 size_flags_vertical = 1
@@ -904,22 +888,22 @@ x1
 "
 vertical_alignment = 1
 
-[node name="VSeparatorSmall" type="VSeparator" parent="Control/MarginContainer/HBoxContainer/FatRecipe"]
+[node name="VSeparatorSmall" type="VSeparator" parent="Control/MarginContainer/HBoxContainer/LargeRecipe"]
 modulate = Color(1, 1, 1, 0)
 layout_mode = 2
 
-[node name="VSeparatorSmall2" type="VSeparator" parent="Control/MarginContainer/HBoxContainer/FatRecipe"]
+[node name="VSeparatorSmall2" type="VSeparator" parent="Control/MarginContainer/HBoxContainer/LargeRecipe"]
 modulate = Color(1, 1, 1, 0)
 layout_mode = 2
 
-[node name="LargeImg" type="TextureRect" parent="Control/MarginContainer/HBoxContainer/FatRecipe"]
+[node name="LargeImg" type="TextureRect" parent="Control/MarginContainer/HBoxContainer/LargeRecipe"]
 custom_minimum_size = Vector2(100, 0)
 layout_mode = 2
 texture = ExtResource("8_nqhld")
 expand_mode = 3
 flip_h = true
 
-[node name="LargeQty" type="Label" parent="Control/MarginContainer/HBoxContainer/FatRecipe"]
+[node name="LargeQty" type="Label" parent="Control/MarginContainer/HBoxContainer/LargeRecipe"]
 layout_mode = 2
 theme_override_colors/font_color = Color(0, 0, 0, 1)
 theme_override_fonts/font = ExtResource("3_nq4v7")
@@ -928,15 +912,11 @@ text = "
 x1
 "
 
-[node name="VSeparatorLarge" type="VSeparator" parent="Control/MarginContainer/HBoxContainer/FatRecipe"]
+[node name="VSeparatorLarge" type="VSeparator" parent="Control/MarginContainer/HBoxContainer/LargeRecipe"]
 modulate = Color(1, 1, 1, 0)
 layout_mode = 2
 
-[node name="VSeparatorLarge2" type="VSeparator" parent="Control/MarginContainer/HBoxContainer/FatRecipe"]
-modulate = Color(1, 1, 1, 0)
-layout_mode = 2
-
-[node name="DotSpacers" type="Label" parent="Control/MarginContainer/HBoxContainer/FatRecipe"]
+[node name="DotSpacers" type="Label" parent="Control/MarginContainer/HBoxContainer/LargeRecipe"]
 layout_mode = 2
 theme_override_colors/font_color = Color(0, 0, 0, 1)
 theme_override_fonts/font = ExtResource("3_nq4v7")
@@ -944,12 +924,12 @@ theme_override_font_sizes/font_size = 22
 text = "
 . . ."
 
-[node name="VSeparatorFinal" type="VSeparator" parent="Control/MarginContainer/HBoxContainer/FatRecipe"]
+[node name="VSeparatorFinal" type="VSeparator" parent="Control/MarginContainer/HBoxContainer/LargeRecipe"]
 visible = false
 modulate = Color(1, 1, 1, 0)
 layout_mode = 2
 
-[node name="LargeProduct" type="TextureRect" parent="Control/MarginContainer/HBoxContainer/FatRecipe"]
+[node name="LargeProduct" type="TextureRect" parent="Control/MarginContainer/HBoxContainer/LargeRecipe"]
 clip_contents = true
 custom_minimum_size = Vector2(100, 0)
 layout_mode = 2

--- a/Scenes/UI/spell_ui.tscn
+++ b/Scenes/UI/spell_ui.tscn
@@ -959,10 +959,10 @@ expand_mode = 5
 
 [node name="CloseButton" parent="Control" instance=ExtResource("2_a30l4")]
 layout_mode = 0
-offset_left = 1677.0
-offset_top = 958.0
-offset_right = 1849.0
-offset_bottom = 1026.0
+offset_left = 37.0
+offset_top = 115.0
+offset_right = 209.0
+offset_bottom = 183.0
 text = "Close"
 
 [node name="Panel" type="Panel" parent="Control"]

--- a/Scenes/UI/spell_ui.tscn
+++ b/Scenes/UI/spell_ui.tscn
@@ -1,7 +1,8 @@
-[gd_scene load_steps=9 format=3 uid="uid://caup4tky6b8g7"]
+[gd_scene load_steps=10 format=3 uid="uid://caup4tky6b8g7"]
 
 [ext_resource type="Script" path="res://Code/UI/spell_ui.gd" id="1_5txb0"]
 [ext_resource type="PackedScene" uid="uid://baeaj55y6xd38" path="res://Scenes/UI/BlankButton.tscn" id="2_a30l4"]
+[ext_resource type="Texture2D" uid="uid://wptdqqdmjfw5" path="res://Assets/Art/button1.png" id="2_x54co"]
 [ext_resource type="FontFile" uid="uid://bg5wgh22jq31n" path="res://Assets/Fonts/MouldyCheeseRegular-WyMWG.ttf" id="3_nq4v7"]
 
 [sub_resource type="Animation" id="Animation_7k4x1"]
@@ -74,15 +75,15 @@ _data = {
 
 [node name="SpellUi" type="CanvasLayer" node_paths=PackedStringArray("text0", "text1", "text2", "text3", "text4", "text5", "text6", "text7", "text8")]
 script = ExtResource("1_5txb0")
-text0 = NodePath("Control/Panel/MarginContainer/HBoxContainer/Text0")
-text1 = NodePath("Control/Panel/MarginContainer/HBoxContainer/Text1")
-text2 = NodePath("Control/Panel/MarginContainer/HBoxContainer/Text2")
-text3 = NodePath("Control/Panel/MarginContainer/HBoxContainer/Text3")
-text4 = NodePath("Control/Panel/MarginContainer/HBoxContainer/Text4")
-text5 = NodePath("Control/Panel/MarginContainer/HBoxContainer/Text5")
-text6 = NodePath("Control/Panel/MarginContainer/HBoxContainer/Text6")
-text7 = NodePath("Control/Panel/MarginContainer/HBoxContainer/Text7")
-text8 = NodePath("Control/Panel/MarginContainer/HBoxContainer/Text8")
+text0 = NodePath("Control/MarginContainer/HBoxContainer/Text0")
+text1 = NodePath("Control/MarginContainer/HBoxContainer/Text1")
+text2 = NodePath("Control/MarginContainer/HBoxContainer/Text2")
+text3 = NodePath("Control/MarginContainer/HBoxContainer/Text3")
+text4 = NodePath("Control/MarginContainer/HBoxContainer/Text4")
+text5 = NodePath("Control/MarginContainer/HBoxContainer/Text5")
+text6 = NodePath("Control/MarginContainer/HBoxContainer/Text6")
+text7 = NodePath("Control/MarginContainer/HBoxContainer/Text7")
+text8 = NodePath("Control/MarginContainer/HBoxContainer/Text8")
 
 [node name="Control" type="Control" parent="."]
 layout_mode = 3
@@ -94,7 +95,121 @@ offset_right = -1927.0
 grow_horizontal = 2
 grow_vertical = 2
 
+[node name="Sprite2D" type="Sprite2D" parent="Control"]
+position = Vector2(960.655, 541.014)
+rotation = 1.5708
+scale = Vector2(0.582018, 2.02846)
+texture = ExtResource("2_x54co")
+
+[node name="MarginContainer" type="MarginContainer" parent="Control"]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_top = 200.0
+offset_bottom = 215.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_constants/margin_left = 10
+theme_override_constants/margin_top = 10
+theme_override_constants/margin_right = 10
+theme_override_constants/margin_bottom = 10
+
+[node name="HBoxContainer" type="VBoxContainer" parent="Control/MarginContainer"]
+layout_mode = 2
+size_flags_horizontal = 4
+theme_override_constants/separation = 24
+
+[node name="Name" type="Label" parent="Control/MarginContainer/HBoxContainer"]
+layout_mode = 2
+theme_override_colors/font_color = Color(0, 0, 0, 1)
+theme_override_fonts/font = ExtResource("3_nq4v7")
+theme_override_font_sizes/font_size = 44
+text = "Spells:
+"
+
+[node name="Text0" type="Label" parent="Control/MarginContainer/HBoxContainer"]
+layout_mode = 2
+theme_override_colors/font_color = Color(0, 0, 0, 1)
+theme_override_fonts/font = ExtResource("3_nq4v7")
+theme_override_font_sizes/font_size = 30
+text = "test
+"
+
+[node name="Text1" type="Label" parent="Control/MarginContainer/HBoxContainer"]
+layout_mode = 2
+theme_override_colors/font_color = Color(0, 0, 0, 1)
+theme_override_fonts/font = ExtResource("3_nq4v7")
+theme_override_font_sizes/font_size = 30
+text = "test
+"
+
+[node name="Text2" type="Label" parent="Control/MarginContainer/HBoxContainer"]
+layout_mode = 2
+theme_override_colors/font_color = Color(0, 0, 0, 1)
+theme_override_fonts/font = ExtResource("3_nq4v7")
+theme_override_font_sizes/font_size = 30
+text = "test
+"
+
+[node name="Text3" type="Label" parent="Control/MarginContainer/HBoxContainer"]
+layout_mode = 2
+theme_override_colors/font_color = Color(0, 0, 0, 1)
+theme_override_fonts/font = ExtResource("3_nq4v7")
+theme_override_font_sizes/font_size = 30
+text = "test
+"
+
+[node name="Text4" type="Label" parent="Control/MarginContainer/HBoxContainer"]
+layout_mode = 2
+theme_override_colors/font_color = Color(0, 0, 0, 1)
+theme_override_fonts/font = ExtResource("3_nq4v7")
+theme_override_font_sizes/font_size = 30
+text = "test
+"
+
+[node name="Text5" type="Label" parent="Control/MarginContainer/HBoxContainer"]
+layout_mode = 2
+theme_override_colors/font_color = Color(0, 0, 0, 1)
+theme_override_fonts/font = ExtResource("3_nq4v7")
+theme_override_font_sizes/font_size = 30
+text = "test
+"
+
+[node name="Text6" type="Label" parent="Control/MarginContainer/HBoxContainer"]
+layout_mode = 2
+theme_override_colors/font_color = Color(0, 0, 0, 1)
+theme_override_fonts/font = ExtResource("3_nq4v7")
+theme_override_font_sizes/font_size = 30
+text = "test
+"
+
+[node name="Text7" type="Label" parent="Control/MarginContainer/HBoxContainer"]
+layout_mode = 2
+theme_override_colors/font_color = Color(0, 0, 0, 1)
+theme_override_fonts/font = ExtResource("3_nq4v7")
+theme_override_font_sizes/font_size = 30
+text = "test
+"
+
+[node name="Text8" type="Label" parent="Control/MarginContainer/HBoxContainer"]
+layout_mode = 2
+theme_override_colors/font_color = Color(0, 0, 0, 1)
+theme_override_fonts/font = ExtResource("3_nq4v7")
+theme_override_font_sizes/font_size = 30
+text = "test
+"
+
+[node name="CloseButton" parent="Control" instance=ExtResource("2_a30l4")]
+layout_mode = 0
+offset_left = 1677.0
+offset_top = 958.0
+offset_right = 1849.0
+offset_bottom = 1026.0
+text = "Close"
+
 [node name="Panel" type="Panel" parent="Control"]
+visible = false
 layout_mode = 1
 anchors_preset = 8
 anchor_left = 0.5
@@ -109,101 +224,6 @@ grow_horizontal = 2
 grow_vertical = 2
 size_flags_horizontal = 4
 
-[node name="MarginContainer" type="MarginContainer" parent="Control/Panel"]
-layout_mode = 1
-anchors_preset = 15
-anchor_right = 1.0
-anchor_bottom = 1.0
-grow_horizontal = 2
-grow_vertical = 2
-theme_override_constants/margin_left = 10
-theme_override_constants/margin_top = 10
-theme_override_constants/margin_right = 10
-theme_override_constants/margin_bottom = 10
-
-[node name="HBoxContainer" type="VBoxContainer" parent="Control/Panel/MarginContainer"]
-layout_mode = 2
-size_flags_horizontal = 4
-theme_override_constants/separation = 24
-
-[node name="Name" type="Label" parent="Control/Panel/MarginContainer/HBoxContainer"]
-layout_mode = 2
-theme_override_fonts/font = ExtResource("3_nq4v7")
-theme_override_font_sizes/font_size = 44
-text = "Spells:
-"
-
-[node name="Text0" type="Label" parent="Control/Panel/MarginContainer/HBoxContainer"]
-layout_mode = 2
-theme_override_fonts/font = ExtResource("3_nq4v7")
-theme_override_font_sizes/font_size = 30
-text = "test
-"
-
-[node name="Text1" type="Label" parent="Control/Panel/MarginContainer/HBoxContainer"]
-layout_mode = 2
-theme_override_fonts/font = ExtResource("3_nq4v7")
-theme_override_font_sizes/font_size = 30
-text = "test
-"
-
-[node name="Text2" type="Label" parent="Control/Panel/MarginContainer/HBoxContainer"]
-layout_mode = 2
-theme_override_fonts/font = ExtResource("3_nq4v7")
-theme_override_font_sizes/font_size = 30
-text = "test
-"
-
-[node name="Text3" type="Label" parent="Control/Panel/MarginContainer/HBoxContainer"]
-layout_mode = 2
-theme_override_fonts/font = ExtResource("3_nq4v7")
-theme_override_font_sizes/font_size = 30
-text = "test
-"
-
-[node name="Text4" type="Label" parent="Control/Panel/MarginContainer/HBoxContainer"]
-layout_mode = 2
-theme_override_fonts/font = ExtResource("3_nq4v7")
-theme_override_font_sizes/font_size = 30
-text = "test
-"
-
-[node name="Text5" type="Label" parent="Control/Panel/MarginContainer/HBoxContainer"]
-layout_mode = 2
-theme_override_fonts/font = ExtResource("3_nq4v7")
-theme_override_font_sizes/font_size = 30
-text = "test
-"
-
-[node name="Text6" type="Label" parent="Control/Panel/MarginContainer/HBoxContainer"]
-layout_mode = 2
-theme_override_fonts/font = ExtResource("3_nq4v7")
-theme_override_font_sizes/font_size = 30
-text = "test
-"
-
-[node name="Text7" type="Label" parent="Control/Panel/MarginContainer/HBoxContainer"]
-layout_mode = 2
-theme_override_fonts/font = ExtResource("3_nq4v7")
-theme_override_font_sizes/font_size = 30
-text = "test
-"
-
-[node name="Text8" type="Label" parent="Control/Panel/MarginContainer/HBoxContainer"]
-layout_mode = 2
-theme_override_fonts/font = ExtResource("3_nq4v7")
-theme_override_font_sizes/font_size = 30
-text = "test
-"
-
-[node name="CloseButton" parent="Control/Panel" instance=ExtResource("2_a30l4")]
-layout_mode = 0
-offset_left = 1217.0
-offset_top = 818.0
-offset_right = 1389.0
-offset_bottom = 886.0
-text = "Close"
-
 [node name="OpenButton" parent="." instance=ExtResource("2_a30l4")]
 offset_left = 37.0
 offset_top = 115.0
@@ -217,5 +237,5 @@ libraries = {
 }
 speed_scale = 3.48
 
-[connection signal="pressed" from="Control/Panel/CloseButton" to="." method="_on_close_button_pressed"]
+[connection signal="pressed" from="Control/CloseButton" to="." method="_on_close_button_pressed"]
 [connection signal="pressed" from="OpenButton" to="." method="_on_open_button_pressed"]

--- a/Scenes/UI/spell_ui.tscn
+++ b/Scenes/UI/spell_ui.tscn
@@ -236,9 +236,10 @@ alignment = 1
 [node name="BasicImg" type="TextureRect" parent="Control/MarginContainer/HBoxContainer/NormRecipe"]
 clip_contents = true
 custom_minimum_size = Vector2(100, 0)
+layout_direction = 1
 layout_mode = 2
 texture = ExtResource("4_o8vp7")
-expand_mode = 5
+expand_mode = 3
 
 [node name="BasicQty" type="Label" parent="Control/MarginContainer/HBoxContainer/NormRecipe"]
 layout_mode = 2


### PR DESCRIPTION
Spellbook UI has improved, text recipes have been removed and replaced with visual representations of spell requirements. Multiple spells per product can be displayed, and spells are parsed directly from the manager. 

Code also has limited ability to revise programmatic recipes with hard-coded additions; currently this is used to specify "any" frog can be used to create a basic frog.

Additionally, main menu and quit buttons were added to pause, and in the main menu "start" was separated into "start" and "level select"