### PR TITLE
Starter frog customization by level added to level manager

### DIFF
--- a/Code/FrogLogic/frog_spawner.gd
+++ b/Code/FrogLogic/frog_spawner.gd
@@ -3,15 +3,22 @@ extends Node
 
 @export var frog_scenes : Array[PackedScene]
 @export var lillypad_parent : Node2D
-@export var starting_frog_count : int
+@export var starting_frog_count = []
 var frog_parents : Array[Node2D]
 signal spawned_frog(frog : BasicFrog)
 
 # Called when the node enters the scene tree for the first time.
 func _ready() -> void:
 	frog_parents = [$BasicFrogs, $TropicalFrogs, $SmallFrogs, $FatFrogs, $MudFrogs, $BrightFrogs, $DartFrogs, $OrangeFrogs, $PurpleFrogs]
-	for i in starting_frog_count:
-		spawn_frog_random_loc(MagicManager.FrogType.BASIC)
+	# set starter frogs
+	starting_frog_count = []
+	if get_tree().root.get_child(0) is Main:
+		# at this point in instantiation only main.gd knows level num
+		var level = get_tree().root.get_child(0).level_num
+		# level manager stores starting frogs per level
+		starting_frog_count = get_tree().root.get_child(0).get_node("LevelManager").set_starter_frogs(level)
+		for i in starting_frog_count:
+			spawn_frog_random_loc(i)
 
 # Called every frame. 'delta' is the elapsed time since the previous frame.
 func _process(delta: float) -> void:

--- a/Code/Managers/LevelManager.gd
+++ b/Code/Managers/LevelManager.gd
@@ -11,6 +11,14 @@ class_name LevelManager extends Node2D
 @export var frog_requests_6 : Array[MagicManager.FrogType]
 @export var frog_requests_7 : Array[MagicManager.FrogType]
 @export var frog_requests_8 : Array[MagicManager.FrogType]
+@export var starter_frogs_1 : Array[MagicManager.FrogType]
+@export var starter_frogs_2 : Array[MagicManager.FrogType]
+@export var starter_frogs_3 : Array[MagicManager.FrogType]
+@export var starter_frogs_4 : Array[MagicManager.FrogType]
+@export var starter_frogs_5 : Array[MagicManager.FrogType]
+@export var starter_frogs_6 : Array[MagicManager.FrogType]
+@export var starter_frogs_7 : Array[MagicManager.FrogType]
+@export var starter_frogs_8 : Array[MagicManager.FrogType]
 
 #@onready var win_screen = preload("res://Scenes/win_screen.tscn") as PackedScene
 
@@ -91,7 +99,31 @@ func check_for_win() -> bool:
 		$WinScreen.visible = true
 	return is_win
 
+func set_starter_frogs(level_starter_frogs) -> Array:
+	var starter_frogs = []
 
+	# Use the stored current_level_num
+	match level_starter_frogs:
+		0:
+			starter_frogs = starter_frogs_1
+		1:
+			starter_frogs = starter_frogs_2
+		2:
+			starter_frogs = starter_frogs_3
+		3:
+			starter_frogs = starter_frogs_4
+		4:
+			starter_frogs = starter_frogs_5
+		5:
+			starter_frogs = starter_frogs_6
+		6:
+			starter_frogs = starter_frogs_7
+		7:
+			starter_frogs = starter_frogs_8
+		_:
+			# if fail, use first level frogs
+			starter_frogs = starter_frogs_1
+	return starter_frogs
 
 #func _process(delta: float) -> void:
 #	check_for_game_over()

--- a/Scenes/Frogs/frog_spawner.tscn
+++ b/Scenes/Frogs/frog_spawner.tscn
@@ -17,7 +17,6 @@ size = Vector2(1474, 299)
 [node name="FrogSpawner" type="Node2D"]
 script = ExtResource("1_4lyrf")
 frog_scenes = Array[PackedScene]([ExtResource("2_02rqu"), ExtResource("3_jj3p0"), ExtResource("4_t7haa"), ExtResource("5_1xgr4"), ExtResource("6_ur5lr"), ExtResource("7_d1d61"), ExtResource("8_364qh"), ExtResource("9_lsugp"), ExtResource("10_ahrss")])
-starting_frog_count = 3
 
 [node name="SpawnArea" type="Area2D" parent="."]
 

--- a/Scenes/Levels/Test/Main-Scene-Tom.tscn
+++ b/Scenes/Levels/Test/Main-Scene-Tom.tscn
@@ -30,6 +30,14 @@ frog_requests_5 = Array[int]([4, 4, 4])
 frog_requests_6 = Array[int]([3])
 frog_requests_7 = Array[int]([2, 2, 2, 2, 2, 2, 3])
 frog_requests_8 = Array[int]([3, 3, 4, 4, 4, 4, 0, 0, 0])
+starter_frogs_1 = Array[int]([0])
+starter_frogs_2 = Array[int]([0, 0])
+starter_frogs_3 = Array[int]([0, 0, 0])
+starter_frogs_4 = Array[int]([0, 0, 0, 0])
+starter_frogs_5 = Array[int]([0, 0, 0, 0, 0])
+starter_frogs_6 = Array[int]([0, 0, 0, 0, 0, 0])
+starter_frogs_7 = Array[int]([0, 0, 0, 0, 0, 0, 0])
+starter_frogs_8 = Array[int]([0, 0, 0, 0, 0, 0, 0, 0])
 
 [node name="MagicManager" parent="." instance=ExtResource("2_k1b8b")]
 


### PR DESCRIPTION
Infrastructure for balance testing added: LevelManager.gd now has properties to specify starting frogs for level, in same structure as orders. Both can be conveniently edited in the same panel.